### PR TITLE
Minimal Firefox support

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -6,6 +6,12 @@
   "version": "1.0",
   "version_name": "1.0 beta",
 
+   "applications": {
+     "gecko": {
+       "id": "gohyper@mozilla.org"
+     }
+   },
+
   "icons": {
     "16": "images/test.png",
     "32": "images/test.png",


### PR DESCRIPTION
Add id to accept extension in Firefox (see https://wiki.mozilla.org/WebExtensions).
