### PR TITLE
include ui-bootstrap css

### DIFF
--- a/html/quote.html
+++ b/html/quote.html
@@ -23,6 +23,7 @@
         <br>
       </span>
     </div>
+
     <div class="input-group">
       <input class="form-control" type="text" name="hyperlinks" ng-model="form.hyperlink"
         uib-typeahead="link for link in links | filter:$viewValue" typeahead-template-url="templates/linkItem.html"

--- a/iframe.html
+++ b/iframe.html
@@ -3,9 +3,10 @@
 <head>
   <meta charset="utf-8">
   <title>GoHyper</title>
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css">
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css">
   <link rel="stylesheet" href="bower_components/angular/angular-csp.css">
+  <link rel="stylesheet" href="bower_components/angular-bootstrap/ui-bootstrap-csp.css">
   <link rel="stylesheet" href="css/gohyper.css">
   <script src="bower_components/angular/angular.min.js"></script>
   <script src="bower_components/angular-route/angular-route.min.js"></script>

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
 
   "name": "GoHyper",
   "description": "Annotate, highlight and interlink text selections on web pages.",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "homepage_url": "https://github.com/jengeb/gohyper",
 
   "icons": {


### PR DESCRIPTION
- include ui-bootstrap css which is necessary for the typeahead input field (inside an extension)
- update bootstrap
